### PR TITLE
Replace 'below' with 'above' in disclaimer

### DIFF
--- a/src/components/Disclaimer.js
+++ b/src/components/Disclaimer.js
@@ -4,7 +4,7 @@ const Disclaimer = ({}) => (
   <div className='disclaimer'>
     <h5>Disclaimer</h5>
     <p>
-      The information below is not the same as legal advice, where an attorney applies the law to your specific circumstances, 
+      The information above is not the same as legal advice, where an attorney applies the law to your specific circumstances, 
       so we insist that you consult an attorney if you’d like advice on your interpretation of this information or its accuracy. 
       In a nutshell, you may not rely on this as legal advice, nor as a recommendation of any particular legal understanding.
     </p>


### PR DESCRIPTION
> The information **below** is not the same as legal advice, ...

Currently, the disclaimer only seems to apply to the content **below** it — the link to privacy policy and the "Makers" section — which doesn't make a lot of sense and is _probably_ not intended. :wink: